### PR TITLE
Fix the bug when the application became unresponsible when minimizing

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -149,6 +149,10 @@ func (gui *GUI) scale() float32 {
 // can only be called on OS thread
 func (gui *GUI) resize(w *glfw.Window, width int, height int) {
 
+	if gui.window.GetAttrib(glfw.Iconified) != 0 {
+		return
+	}
+
 	gui.resizeLock.Lock()
 	defer gui.resizeLock.Unlock()
 


### PR DESCRIPTION
## Description

When minimizing window, OpenGL calls `framebuffer_size_callback` with `width` and `height` parameters set to zero. That was leading to incorrect calculations, so the program tried to allocate a very large buffer, exhausting the memory and crashing on Out Of Memory error.

## Type of change

Basically, we're disabling processing of the framebuffer size change callback when the window is minimized. That prevents from doing unnecessary calculations and reallocations of the buffer when the window is minimized.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run Aminal as usual, then try to minimize the window and restore it back again. The program should not stop responding or crash.

**Test Configuration**:
* OS: `Windows`
