### PR TITLE
Fix -ignore-config flag behavior

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,14 +9,13 @@ import (
 	"path/filepath"
 	"github.com/liamg/aminal/config"
 	"github.com/liamg/aminal/version"
-	"strings"
 )
 
-func isFlagProvided(flagName string) bool {
-	result := false
+func getActuallyProvidedFlags() map[string]bool {
+	result := make(map[string]bool)
 
 	flag.Visit(func(f *flag.Flag) {
-		result = strings.Compare(f.Name, flagName) == 0
+		result[f.Name] = true
 	})
 
 	return result
@@ -36,6 +35,7 @@ func getConfig() *config.Config {
 	flag.BoolVar(&slomo, "slomo", slomo, "Render in slow motion (useful for debugging)")
 
 	flag.Parse()  // actual parsing and fetching flags from the command line
+	actuallyProvidedFlags := getActuallyProvidedFlags()
 
 	if showVersion {
 		v := version.Version
@@ -54,15 +54,15 @@ func getConfig() *config.Config {
 	}
 
 	// Override values in the configuration file with the values specified in the command line, if any.
-	if isFlagProvided("shell") {
+	if actuallyProvidedFlags["shell"] {
 		conf.Shell = shell
 	}
 
-	if isFlagProvided("debug") {
+	if actuallyProvidedFlags["debug"] {
 		conf.DebugMode = debugMode
 	}
 
-	if isFlagProvided("slomo") {
+	if actuallyProvidedFlags["slomo"] {
 		conf.Slomo = slomo
 	}
 


### PR DESCRIPTION
## Description

Previously, the `-ignore-config` command-line flag was not working. Now it works according to the following logic:

- If the `-ignore-config` is specified then the built-in configuration defaults are used, else Aminal tries to load configuration file.
- The parameters `-shell`, `-debug`, and `-slomo` are actually overriding corresponding values specified in the configuration (whether default or loaded from a configuration file).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Run Aminal without parameters to ensure the default configuration file is created, and then close.
- Edit `%USERPROFILE%\.config\aminal\config.toml` and change `shell` parameter to `"cmd.exe /K echo test"`.
- Run Aminal without parameters again and see the `test` text at the top of the Aminal window. That proves that it uses the shell specified in the configuration file. Close Aminal.
- Run Aminal with `-shell cmd.exe` parameter. Now there will be no `test` message. This proves that the `shell` configuration parameter has been overridden. Close Aminal.
- Run Aminal with `-ignore-config` parameter. Again, there will be no `test` message. This proves that the entire configuration file has been ignored and the built-in default configuration has been used.

**Test Configuration**:
* OS: `Windows`
* OS version: `10`
* Go version: `go1.11.2 windows/amd64`
