### PR TITLE
Bug: mouse cursors leaks

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -36,6 +36,8 @@ type GUI struct {
 	showDebugInfo     bool
 	keyboardShortcuts map[config.UserAction]*config.KeyCombination
 	resizeLock        *sync.Mutex
+	handCursor        *glfw.Cursor
+	arrowCursor       *glfw.Cursor
 }
 
 func Min(x, y int) int {

--- a/gui/mouse.go
+++ b/gui/mouse.go
@@ -17,6 +17,22 @@ func (gui *GUI) glfwScrollCallback(w *glfw.Window, xoff float64, yoff float64) {
 	}
 }
 
+func (gui *GUI) getHandCursor() *glfw.Cursor {
+	if gui.handCursor == nil {
+		gui.handCursor = glfw.CreateStandardCursor(glfw.HandCursor)
+	}
+
+	return gui.handCursor
+}
+
+func (gui  *GUI) getArrowCursor() *glfw.Cursor {
+	if gui.arrowCursor == nil {
+		gui.arrowCursor = glfw.CreateStandardCursor(glfw.ArrowCursor)
+	}
+
+	return gui.arrowCursor
+}
+
 func (gui *GUI) mouseMoveCallback(w *glfw.Window, px float64, py float64) {
 
 	scale := gui.scale()
@@ -40,9 +56,9 @@ func (gui *GUI) mouseMoveCallback(w *glfw.Window, px float64, py float64) {
 	}
 
 	if url := gui.terminal.ActiveBuffer().GetURLAtPosition(x, y); url != "" {
-		w.SetCursor(glfw.CreateStandardCursor(glfw.HandCursor))
+		w.SetCursor(gui.getHandCursor())
 	} else {
-		w.SetCursor(glfw.CreateStandardCursor(glfw.ArrowCursor))
+		w.SetCursor(gui.getArrowCursor())
 	}
 }
 


### PR DESCRIPTION
## Description

If you move mouse cursor inside Aminal's window for long time, the log gets filled with "Failed to create standard cursor" error message which actually means that the system resources are have been exhausted. Mouse cursors are leaking because Aminal creates a new cursor on every mouse move.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Move mouse cursor inside Aminal's window for a two minutes or so. The "Failed to create standard cursor" error message should not appear in the log.

**Test Configuration**:
* OS: `Windows`
* Go version: `go1.11.2 windows/amd64`
