### PR TITLE
Erase cell with default background colour

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -837,7 +837,7 @@ func (buffer *Buffer) EraseLineToCursor() {
 	line := buffer.getCurrentLine()
 	for i := 0; i <= int(buffer.cursorX); i++ {
 		if i < len(line.cells) {
-			line.cells[i].erase()
+			line.cells[i].erase(buffer.defaultCell.attr.BgColour)
 		}
 	}
 }
@@ -898,7 +898,7 @@ func (buffer *Buffer) EraseCharacters(n int) {
 	}
 
 	for i := int(buffer.cursorX); i < max; i++ {
-		line.cells[i].erase()
+		line.cells[i].erase(buffer.defaultCell.attr.BgColour)
 	}
 }
 
@@ -928,7 +928,7 @@ func (buffer *Buffer) EraseDisplayToCursor() {
 		if i >= len(line.cells) {
 			break
 		}
-		line.cells[i].erase()
+		line.cells[i].erase(buffer.defaultCell.attr.BgColour)
 	}
 	for i := uint16(0); i < buffer.cursorY; i++ {
 		rawLine := buffer.convertViewLineToRawLine(i)

--- a/buffer/cell.go
+++ b/buffer/cell.go
@@ -53,8 +53,9 @@ func (cell *Cell) Bg() [3]float32 {
 	return cell.attr.BgColour
 }
 
-func (cell *Cell) erase() {
+func (cell *Cell) erase(bgColour  [3]float32) {
 	cell.setRune(0)
+	cell.attr.BgColour = bgColour
 }
 
 func (cell *Cell) setRune(r rune) {


### PR DESCRIPTION
## Description

Erasing of cell should also reset background cell colour

Fixes #127 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Run command in terminal to let it change background color of some terminal's cells
- Clear screen (`CLS` on Windows) and verify that no artifacts left at the screen
