### PR TITLE
Correct handling of DeviceAttributes request

### DIFF
--- a/terminal/csi.go
+++ b/terminal/csi.go
@@ -91,12 +91,28 @@ CSI:
 
 func csiSendDeviceAttributesHandler(params []string, intermediate string, terminal *Terminal) error {
 
-	if len(params) > 0 && len(params[0]) > 0 && params[0][0] == '>' { // secondary
-		_ = terminal.Write([]byte("\x1b[0;0;0c")) // report VT100
-		return nil
+	// we are VT100
+	// for DA1 we'll respond 1;2
+	// for DA2 we'll respond 0;0;0
+
+	response := "1;2"
+
+	if len(params) > 0 {
+		param, err := strconv.Atoi(params[0])
+
+		if err != nil {
+			return fmt.Errorf("Invalid parameter in DA request: %s", params[0])
+		}
+
+		if param > 0 {
+			// DA2
+			response = "0;0;0"
+		}
 	}
 
-	return fmt.Errorf("Unsupported SDA identifier")
+	_ = terminal.Write([]byte("\x1b[?" + response + "c"))
+
+	return nil
 }
 
 func csiDeviceStatusReportHandler(params []string, intermediate string, terminal *Terminal) error {


### PR DESCRIPTION
## Description

`vttest` didn't start because of incorrect handling of Device Attributes request.
Now it starts correctly

Fixes #120 (partially)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

start `vttest`
Initial screen appears, saying "VT100 test program etc."

**Test Configuration**:
* OS: Ubuntu
* OS version: 18.04
* Go version: 1.11

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

