### PR TITLE
Changes to minimize memory allocations and to ensure OpenGL objects cleanup

### DIFF
--- a/glfont/truetype.go
+++ b/glfont/truetype.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-gl/gl/all-core/gl"
 	"github.com/golang/freetype/truetype"
+	"golang.org/x/image/font"
 )
 
 type character struct {
@@ -17,14 +18,14 @@ type character struct {
 	bearingV  int    //glyph bearing vertical
 }
 
-//LoadTrueTypeFont builds a set of textures based on a ttf files gylphs
+//LoadTrueTypeFont builds a set of textures based on a ttf files glyphs
 func LoadTrueTypeFont(program uint32, r io.Reader, scale float32) (*Font, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 
-	//make Font stuct type
+	//make Font struct type
 	f := new(Font)
 	f.scale = scale
 	f.characters = map[rune]*character{}
@@ -61,6 +62,13 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale float32) (*Font, error)
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	gl.BindVertexArray(0)
+
+	//create new face to measure glyph dimensions
+	f.ttfFace = truetype.NewFace(f.ttf, &truetype.Options {
+		Size:    float64(f.scale),
+		DPI:     DPI,
+		Hinting: font.HintingFull,
+	})
 
 	return f, nil
 }

--- a/gui/fontmap.go
+++ b/gui/fontmap.go
@@ -14,6 +14,26 @@ func NewFontMap(defaultFont *glfont.Font, defaultBoldFont *glfont.Font) *FontMap
 	}
 }
 
+func (fm *FontMap) Free() {
+	if fm.defaultFont != nil {
+		fm.defaultFont.Free()
+		fm.defaultFont = nil
+	}
+
+	if fm.defaultBoldFont != nil {
+		fm.defaultBoldFont.Free()
+		fm.defaultBoldFont = nil
+	}
+}
+
+func (fm *FontMap) AssignFonts(defaultFont *glfont.Font, defaultBoldFont *glfont.Font) {
+	fm.defaultFont.Free()
+	fm.defaultBoldFont.Free()
+
+	fm.defaultFont = defaultFont
+	fm.defaultBoldFont = defaultBoldFont
+}
+
 func (fm *FontMap) UpdateResolution(w int, h int) {
 	fm.defaultFont.UpdateResolution(w, h)
 	fm.defaultBoldFont.UpdateResolution(w, h)

--- a/gui/fonts.go
+++ b/gui/fonts.go
@@ -40,8 +40,7 @@ func (gui *GUI) loadFonts() error {
 	if gui.fontMap == nil {
 		gui.fontMap = NewFontMap(defaultFont, boldFont)
 	} else {
-		gui.fontMap.defaultFont = defaultFont
-		gui.fontMap.defaultBoldFont = boldFont
+		gui.fontMap.AssignFonts(defaultFont, boldFont)
 	}
 
 	// add special non-ascii fonts here

--- a/gui/renderer.go
+++ b/gui/renderer.go
@@ -155,7 +155,6 @@ func (rect *rectangle) setColour(colour [3]float32) {
 }
 
 func (rect *rectangle) Free() {
-	gl.UseProgram(rect.prog)
 	gl.DeleteVertexArrays(1, &rect.vao)
 	gl.DeleteBuffers(1, &rect.vbo)
 	gl.DeleteBuffers(1, &rect.cv)
@@ -181,6 +180,24 @@ func NewOpenGLRenderer(config *config.Config, fontMap *FontMap, areaX int, areaY
 	}
 	r.SetArea(areaX, areaY, areaWidth, areaHeight)
 	return r
+}
+
+// This method ensures that all OpenGL resources are deleted correctly
+func (r *OpenGLRenderer) Free() {
+	for _, rect := range r.rectangles {
+		rect.Free()
+	}
+	r.rectangles = map[[2]uint]*rectangle{}
+
+	for _, tex := range r.textureMap {
+		gl.DeleteTextures(1, &tex)
+	}
+	r.textureMap = map[*image.RGBA]uint32{}
+
+	r.fontMap.Free()
+
+	gl.DeleteProgram(r.program)
+	r.program = 0
 }
 
 func (r *OpenGLRenderer) GetTermSize() (uint, uint) {


### PR DESCRIPTION
## Description

- Now all OpenGL objects, such as textures, buffers, and programs, are correctly removed at the end of the program. 
- `font.Face` now created at the font loading, and not at every resize of the window. This minimizes memory allocations and slightly speeds up rendering.
- `strings.Builder` is used instead of constant concatenating strings in `func (gui *GUI) redraw(defaultCell buffer.Cell) `

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
