### PR TITLE
In order to cope with high memory consumption, remove the 'rectangles'…

### DIFF
--- a/gui/textbox.go
+++ b/gui/textbox.go
@@ -79,8 +79,6 @@ DONE:
 		addLine()
 	}
 
-	gui.renderer.Clean()
-
 	for hx := col; hx < col+uint16(longestLine)+1; hx++ {
 		for hy := row - 1; hy < row+uint16(len(lines))+1; hy++ {
 			gui.renderer.DrawCellBg(buffer.NewBackgroundCell(bg), uint(hx), uint(hy), false, nil, true)


### PR DESCRIPTION
## Description

In order to cope with high memory consumption, remove the `rectangles` member from OpenGLRenderer structure.

The `rectangles` member was acting like a strange cache. Removing them does not lead to any noticeable performance degradation, but gives a huge reduction in RAM. Under the same conditions when previously Aminal consumed more than 1GB, now it takes only about 150MB of memory. (This is on Windows; on Linux I didn't notice any change - most probably this is because of differences how  OpenGL uses memory).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
