### PR TITLE
Map input key codes to lower case

### DIFF
--- a/gui/input.go
+++ b/gui/input.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
@@ -56,7 +57,7 @@ func (gui *GUI) key(w *glfw.Window, key glfw.Key, scancode int, action glfw.Acti
 		// get key name to handle alternative keyboard layouts
 		name := glfw.GetKeyName(key, scancode)
 		if len(name) == 1 {
-			r := rune(name[0])
+			r := rune(strings.ToLower(name)[0])
 			for userAction, shortcut := range gui.keyboardShortcuts {
 				if shortcut.Match(mods, r) {
 					f, ok := actionMap[userAction]


### PR DESCRIPTION
## Description

Resolves hotkey triggering issue.
Only lower case key codes are [expected ](https://github.com/liamg/aminal/blob/18c8ca4754682022e9979b3016bc0c606ae1bc61/config/keys.go#L39) for hotkeys.

Fixes #143 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Some text selected by mouse pointer
- ctrl + shift + c to copy selected text into clipboard
- ctrl + shift + v to paste from clipboard

**Test Configuration**:
* OS: Windows
* OS version: 1809
* Go version:  go1.11.2 windows/amd64
