### PR TITLE
Prevent shell program from keeping alive after Aminal is closed

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func initialize(fn callback) {
 		pty.Close()
 		logger.Fatalf("Failed to start your shell: %s", err)
 	}
+	defer guestProcess.Close()
 
 	logger.Infof("Creating terminal...")
 	terminal := terminal.New(pty, logger, conf)


### PR DESCRIPTION
## Description

On closing Aminal window, the shell program (i.e. `cmd.exe`) was not terminating and kept running. Now it is explicitly killed. Also, I changed `winproc.go` so that it now uses Go-native approach to killing and waiting the child process.

Fixes #135 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The behavior described in #135 should not happen anymore.

**Test Configuration**:
* OS: `Windows`
