### PR TITLE
Clear selection on "reset mode" sequence

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -282,6 +282,14 @@ func (buffer *Buffer) EndSelection(col uint16, viewRow uint16, complete bool) {
 	}
 }
 
+func (buffer *Buffer) ClearSelection() {
+	buffer.selectionStart = nil
+	buffer.selectionEnd = nil
+	buffer.selectionComplete = true
+
+	buffer.emitDisplayChange()
+}
+
 func (buffer *Buffer) InSelection(col uint16, row uint16) bool {
 
 	if buffer.selectionStart == nil || buffer.selectionEnd == nil {

--- a/terminal/csi.go
+++ b/terminal/csi.go
@@ -422,6 +422,7 @@ func csiEraseCharactersHandler(params []string, terminal *Terminal) error {
 }
 
 func csiResetModeHandler(params []string, terminal *Terminal) error {
+	terminal.ActiveBuffer().ClearSelection()
 	return csiSetMode(strings.Join(params, ""), false, terminal)
 }
 

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -89,7 +89,7 @@ func New(pty platform.Pty, logger *zap.SugaredLogger, config *config.Config) *Te
 		},
 		platformDependentSettings: pty.GetPlatformDependentSettings(),
 	}
-	t.activeBuffer = t.buffers[0]
+	t.activeBuffer = t.buffers[MainBuffer]
 	return t
 
 }


### PR DESCRIPTION
## Description

When switching between `tmux` windows the selection is not cleared. This PR fixes this issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run Aminal, ssh to a Linux box, and run `tmux`. 
2. Then create two windows (Ctrl-B + c)
3. Make some selection with the mouse.
4. Switch to another window in `tmux` (Ctrl-B + 0)
5. The selection should clear.
