### PR TITLE
Make launching URLs on Windows work

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -6,7 +6,6 @@ import (
 	"image/png"
 	"math"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ import (
 	"github.com/liamg/aminal/terminal"
 	"github.com/liamg/aminal/version"
 	"go.uber.org/zap"
+	"github.com/liamg/aminal/platform"
 )
 
 type GUI struct {
@@ -621,17 +621,9 @@ func (gui *GUI) createProgram() (uint32, error) {
 
 func (gui *GUI) launchTarget(target string) {
 
-	cmd := "xdg-open"
-
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = "open"
-	case "windows":
-		cmd = "start"
-	}
-
-	if err := exec.Command(cmd, target).Run(); err != nil {
-		gui.logger.Errorf("Failed to launch external command %s: %s", cmd, err)
+	err := platform.LaunchTarget(target)
+	if err != nil {
+		gui.logger.Errorf("Failed to launch target %s: %s", target, err)
 	}
 }
 

--- a/platform/darwinLaunch.go
+++ b/platform/darwinLaunch.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package platform
+
+import (
+	"os/exec"
+)
+
+func LaunchTarget(target string) error {
+	return exec.Command("open", target).Run()
+}

--- a/platform/linuxLaunch.go
+++ b/platform/linuxLaunch.go
@@ -1,0 +1,11 @@
+// +build linux
+
+package platform
+
+import (
+	"os/exec"
+)
+
+func LaunchTarget(target string) error {
+	return exec.Command("xdg-open", target).Run()
+}

--- a/platform/winLaunch.go
+++ b/platform/winLaunch.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package platform
+
+import (
+	"github.com/MaxRis/w32"
+)
+
+func LaunchTarget(target string) error {
+	return w32.ShellExecute(0, "", target, "", "", w32.SW_SHOW)
+}


### PR DESCRIPTION
## Description

This PR allows URLs to be opened correctly on Windows. Also, I moved the platform-dependent code for launching URLs from the `gui` module to `platform`.

Fixes #149

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Open Aminal and type ` http://www.google.com` at the command prompt. Then click left mouse button on the typed URL. The URL should be opened in a system-default browser.

**Test Configuration**:
* OS: `Windows`
