### PR TITLE
Fix issue: sometimes it cuts selected text when copying to clipboard

### DIFF
--- a/gui/actions.go
+++ b/gui/actions.go
@@ -18,7 +18,11 @@ var actionMap = map[config.UserAction]func(gui *GUI){
 }
 
 func actionCopy(gui *GUI) {
-	gui.window.SetClipboardString(gui.terminal.ActiveBuffer().GetSelectedText())
+	selectedText := gui.terminal.ActiveBuffer().GetSelectedText()
+
+	if selectedText != "" {
+		gui.window.SetClipboardString(selectedText)
+	}
 }
 
 func actionPaste(gui *GUI) {


### PR DESCRIPTION
## Description

Sometimes terminal cells contain runes with code 0x0000 (which seems ok). But when putting such a text with embedded zeroes into clipboard the text was cut on the first zero rune. So, now those zero runes are replacing with spaces when putting text to clipboard.
Also, I did some refactoring and used `strings.Builder` instead of concatenating the string, in order to minimize memory allocations.

Fixes #169 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Run Aminal on Windows and SSH to a Linux box (this increases the possibility of zero runes). 
2. Select several lines on the screen and press `Ctrl+Shift+C` to copy the selected text
3. Open `notepad` and press `Ctrl+V` there. See that all the selected text is pasted from the clipboard.

**Test Configuration**:
* OS: `any supported`