### PR TITLE
Fix the bug when carriage returns doubled on input

### DIFF
--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -118,6 +118,8 @@ func TestBufferWriteIncrementsCursorCorrectly(t *testing.T) {
 
 func TestWritingNewLineAsFirstRuneOnWrappedLine(t *testing.T) {
 	b := NewBuffer(NewTerminalState(3, 20, CellAttributes{}, 1000))
+	b.terminalState.LineFeedMode = false
+
 	b.Write('a', 'b', 'c')
 	assert.Equal(t, uint16(3), b.terminalState.cursorX)
 	assert.Equal(t, uint16(0), b.terminalState.cursorY)
@@ -141,6 +143,7 @@ func TestWritingNewLineAsFirstRuneOnWrappedLine(t *testing.T) {
 
 func TestWritingNewLineAsSecondRuneOnWrappedLine(t *testing.T) {
 	b := NewBuffer(NewTerminalState(3, 20, CellAttributes{}, 1000))
+	b.terminalState.LineFeedMode = false
 	/*
 		|abc
 		|d
@@ -624,6 +627,7 @@ dbye
 
 func TestBufferMaxLines(t *testing.T) {
 	b := NewBuffer(NewTerminalState(80, 2, CellAttributes{}, 2))
+	b.terminalState.LineFeedMode = false
 
 	b.Write([]rune("hello")...)
 	b.NewLine()

--- a/buffer/terminal_state.go
+++ b/buffer/terminal_state.go
@@ -30,6 +30,7 @@ func NewTerminalState(viewCols uint16, viewLines uint16, attr CellAttributes, ma
 		viewHeight:   viewLines,
 		topMargin:    0,
 		bottomMargin: uint(viewLines - 1),
+		LineFeedMode: true,
 	}
 	b.TabReset()
 	return b


### PR DESCRIPTION
## Description

This PR sets the terminal's `LineFeedMode` to `true` by default. It seems that this mode should be set by default to work properly on all OSes.

Fixes #171 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The behavior described in issue #171 is not reproduced anymore.

**Test Configuration**:
* OS: `Windows` and `Linux`
