### PR TITLE
Implement three selection modes: char, word, and line

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -54,6 +54,7 @@ type GUI struct {
 	prevLeftClickY    uint16
 	leftClickTime     time.Time
 	leftClickCount    int  // number of clicks in a serie - single click, double click, or triple click
+	mouseMovedAfterSelectionStarted bool
 }
 
 func Min(x, y int) int {


### PR DESCRIPTION
## Description

This PR implements three selection modes: char, word, and line and makes selection work in the same way as in Putty.

Fixes # 170 (partially, there is no scrolling on selection yet)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Moving the mouse with pressed left button selects text in `char` mode, that is, char by char.
2. Double click selects word under the mouse pointer. If don't release the mouse button after the second click and start dragging the mouse then the text will be selected in `word` mode (whole words are selected).
3. Triple click selects the whole line under the mouse pointer. If don't release the mouse button after the third click and start dragging the mouse then the text will be selected in `line` mode (whole lines are selected).

**Test Configuration**:
* OS: `Windows` and `Linux`
