### PR TITLE
bug fix: character under cursor rendering

### DIFF
--- a/gui/renderer.go
+++ b/gui/renderer.go
@@ -199,23 +199,14 @@ func (r *OpenGLRenderer) DrawCursor(col uint, row uint, colour config.Colour) {
 	rect.Free()
 }
 
-func (r *OpenGLRenderer) DrawCellBg(cell buffer.Cell, col uint, row uint, cursor bool, colour *config.Colour, force bool) {
+func (r *OpenGLRenderer) DrawCellBg(cell buffer.Cell, col uint, row uint, colour *config.Colour, force bool) {
 
 	var bg [3]float32
 
 	if colour != nil {
 		bg = *colour
 	} else {
-
-		if cursor {
-			if r.config.ColourScheme.Cursor != r.backgroundColour {
-				bg = r.config.ColourScheme.Cursor
-			} else {
-				bg = cell.Fg()
-			}
-		} else {
-			bg = cell.Bg()
-		}
+		bg = cell.Bg()
 	}
 
 	if bg != r.backgroundColour || force {

--- a/gui/textbox.go
+++ b/gui/textbox.go
@@ -81,7 +81,7 @@ DONE:
 
 	for hx := col; hx < col+uint16(longestLine)+1; hx++ {
 		for hy := row - 1; hy < row+uint16(len(lines))+1; hy++ {
-			gui.renderer.DrawCellBg(buffer.NewBackgroundCell(bg), uint(hx), uint(hy), false, nil, true)
+			gui.renderer.DrawCellBg(buffer.NewBackgroundCell(bg), uint(hx), uint(hy), nil, true)
 		}
 	}
 


### PR DESCRIPTION
## Description

Correctly displays the character under the cursor

Fixes # 182

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Start an uncoloured bash shell in aminal.
2. Type some text.
3. Use the arrow keys to move the cursor back.
4. The character under the block cursor should be inverted and visible

**Test Configuration**:
* OS: Windows, Ubuntu
* OS version: any
* Go version: 1.10.4

