### PR TITLE
Use primary monitor for DPI calc if monitor could be determined

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -19,10 +19,10 @@ import (
 	"github.com/kbinani/screenshot"
 	"github.com/liamg/aminal/buffer"
 	"github.com/liamg/aminal/config"
+	"github.com/liamg/aminal/platform"
 	"github.com/liamg/aminal/terminal"
 	"github.com/liamg/aminal/version"
 	"go.uber.org/zap"
-	"github.com/liamg/aminal/platform"
 )
 
 type GUI struct {
@@ -80,7 +80,6 @@ type ResizeCache struct {
 }
 
 func (g *GUI) GetMonitor() *glfw.Monitor {
-
 	if g.window == nil {
 		panic("to determine current monitor the window must be set")
 	}
@@ -107,7 +106,8 @@ func (g *GUI) GetMonitor() *glfw.Monitor {
 	}
 
 	if currentMonitor == nil {
-		panic("was not able to resolve current monitor")
+		// Monitor couldn't be found (xrandr scaling?) - default to primary
+		return glfw.GetPrimaryMonitor()
 	}
 
 	return currentMonitor


### PR DESCRIPTION
## Description

If the monitor for the window cannot be determined then use the default monitor instead of panicking. 
Panics were occuring for me when aminal's window was in specific places on a specific monitor because I use xrandr's --scale option which glfw doesn't account for.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Started aminal so that it appears on the far right of a monitor using `xrandr --scale`. Previously it would panic, now it starts (and with a sensible DPI scale).

**Test Configuration**:

* OS: Ubuntu
* OS version: 16.04
* Go version: 1.11.5.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

