### PR TITLE
Add dpi-scale config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ shell = "/bin/bash"         # The shell to run for the terminal session. Default
 search_url = "https://www.google.com/search?q=$QUERY" # The search engine to use for the "search selected text" action. Defaults to google. Set this to your own search url using $QUERY as the keywords to replace when searching.
 max_lines = 1000            # Maximum number of lines in the terminal buffer.
 copy_and_paste_with_mouse = true # Text selected with the mouse is copied to the clipboard on end selection, and is pasted on right mouse button click.
+dpi-scale = 0.0             # Override DPI scale. Defaults to 0.0 (let Aminal determine the DPI scale itself).
 
 [colours]
   cursor        = "#e8dfd6" 

--- a/config/config.go
+++ b/config/config.go
@@ -7,14 +7,15 @@ import (
 )
 
 type Config struct {
-	DebugMode    bool             `toml:"debug"`
-	Slomo        bool             `toml:"slomo"`
-	ColourScheme ColourScheme     `toml:"colours"`
-	Shell        string           `toml:"shell"`
-	KeyMapping   KeyMappingConfig `toml:"keys"`
-	SearchURL    string           `toml:"search_url"`
-	MaxLines     uint64           `toml:"max_lines"`
-	CopyAndPasteWithMouse bool    `toml:"copy_and_paste_with_mouse"`
+	DebugMode             bool             `toml:"debug"`
+	Slomo                 bool             `toml:"slomo"`
+	ColourScheme          ColourScheme     `toml:"colours"`
+	DPIScale              float32          `toml:"dpi-scale"`
+	Shell                 string           `toml:"shell"`
+	KeyMapping            KeyMappingConfig `toml:"keys"`
+	SearchURL             string           `toml:"search_url"`
+	MaxLines              uint64           `toml:"max_lines"`
+	CopyAndPasteWithMouse bool             `toml:"copy_and_paste_with_mouse"`
 }
 
 type KeyMappingConfig map[string]string


### PR DESCRIPTION
## Description

This PR adds a new `dpi-scale` configuration option which overrides Aminal's own DPI scale calculation. This is useful for working around unusual monitor setups or users just who prefer a different DPI scale.

If `dpi-scale` is set in aminal.toml then this value overrides aminal's own DPI calculation. 

Potential follow-up work: extend this so that Aminal will detect and query the running Linux desktop environment (Gnome, KDE etc) for any for a desktop scaling factor configured there. 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

Ran aminal with a variety of `dpi-scale` settings as well as ensuring it behaves as before when `dpi-scale` is 0.

**Test Configuration**:

* OS: Ubuntu
* OS version: 16.04
* Go version: 1.11.5

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
