### PR TITLE
Recalculate monitor based DPI scale if Window moved

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -340,6 +340,8 @@ func (gui *GUI) Render() error {
 			gui.terminal.SetDirty()
 		}
 	})
+	gui.window.SetPosCallback(gui.windowPosChangeCallback)
+	glfw.SetMonitorCallback(gui.monitorChangeCallback)
 
 	gui.generateDefaultCell(false)
 
@@ -735,3 +737,12 @@ func (gui *GUI) Screenshot(path string) {
 	defer file.Close()
 	png.Encode(file, img)
 }
+
+func (gui *GUI) windowPosChangeCallback(w *glfw.Window, xpos int, ypos int) {
+	gui.SetDPIScale()
+}
+
+func (gui *GUI) monitorChangeCallback(monitor *glfw.Monitor, event glfw.MonitorEvent) {
+	gui.SetDPIScale()
+}
+

--- a/platform/winproc.go
+++ b/platform/winproc.go
@@ -19,9 +19,11 @@ package platform
 //            PVOID                        lpPreviousValue,
 //            PSIZE_T                      lpReturnSize
 //      );
+//  typedef BOOL (* SetProcessDpiAwarenessContextType)(handle_t);
 //
 //  InitializeProcThreadAttributeListProcType pfnInitializeProcThreadAttributeList = NULL;
 //  UpdateProcThreadAttributeProcType pfnUpdateProcThreadAttribute = NULL;
+//  SetProcessDpiAwarenessContextType pfnSetProcessDpiAwarenessContext = NULL;
 //
 //  #define ProcThreadAttributePseudoConsole 22
 //
@@ -42,6 +44,10 @@ package platform
 //      STARTUPINFOW                 StartupInfo;
 //      LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
 //  } STARTUPINFOEXW, *LPSTARTUPINFOEXW;
+//
+//   #ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+//   #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((handle_t)-4)
+//   #endif
 //
 //  HMODULE hLibKernel32_Proc = NULL;
 //
@@ -65,6 +71,22 @@ package platform
 //          return -1;
 //      }
 //
+//      return 0;
+//  }
+//
+//  DWORD enableHiDpiSupport() {
+//      HMODULE hLibUser32_Proc = LoadLibrary( "User32.dll" );
+//      if( hLibUser32_Proc == NULL )
+//      {
+//          return -1;
+//      }
+//
+//      pfnSetProcessDpiAwarenessContext = (SetProcessDpiAwarenessContextType) GetProcAddress(hLibUser32_Proc, "SetProcessDpiAwarenessContext" );
+//      if( pfnInitializeProcThreadAttributeList == NULL )
+//      {
+//          return -1;
+//      }
+//      (*pfnSetProcessDpiAwarenessContext)( DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 );
 //      return 0;
 //  }
 //
@@ -152,6 +174,9 @@ var procsInitSucceeded = false
 
 func init() {
 	ret := int(C.initProcKernFuncs())
+	if ret == 0 {
+		ret = int(C.enableHiDpiSupport())
+	}
 	procsInitSucceeded = (ret == 0)
 }
 


### PR DESCRIPTION
## Description

- Aminal tries to detect actual monitor dpi scale if application window was moved by user.
- Windows API `SetProcessDpiAwarenessContext` is called to enable window's non-client area aware about different DPI of connected monitors.

Fixes #203 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Laptop with external HiDpi display

**Test Configuration**:
* OS: Windows 1809

Known issues:

- Mouse pointer cursor size is not get adjusted for new underlying monitor's dpi scale.
- GLFW 3.2 has issue with updating connected displays count. In GLFW 3.3 these issues should be resolved, but meanwhile Aminal won't scale correctly if it was launched initially only with single monitor connected.
