### PR TITLE
xdg-open launch target support for bsd systems

### DIFF
--- a/platform/linuxLaunch.go
+++ b/platform/linuxLaunch.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd netbsd openbsd
 
 package platform
 


### PR DESCRIPTION
Makes `LaunchTarget` available on *bsd platforms

Fixes #208 