### PR TITLE
Use DEL for backspace

### DIFF
--- a/gui/input.go
+++ b/gui/input.go
@@ -227,7 +227,7 @@ func (gui *GUI) key(w *glfw.Window, key glfw.Key, scancode int, action glfw.Acti
 			if modsPressed(mods, glfw.ModAlt) {
 				gui.terminal.Write([]byte{0x17}) // ctrl-w/delete word
 			} else {
-				gui.terminal.Write([]byte{0x8})
+				gui.terminal.Write([]byte{0x7f}) // 0x7f is DEL
 			}
 		case glfw.KeyUp:
 			if modStr != "" {


### PR DESCRIPTION
## Description

Use DEL (0x7F) instead of BS (0x08) for backspace/erase. This is the
default for most Linux terminals (and works on Windows too).

See also:
- https://www.asciihex.com/character/control/127/0x7F/del-delete-character
- https://vi.stackexchange.com/a/3120

Fixes #178 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Confirmed that backspace key works as expected with:
- zsh on Linux using both my personal config which previous failed due to ^H binding
- zsh on Linux using stock config (`zsh -f`)
- bash on Linux using stock config
- Windows with cmd.exe
- Windows with powershell

**Test Configuration**:
* OS: See above
* Go version: 1.11.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
