### PR TITLE
Travis nightly builds from cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,23 @@ env:
 before_deploy:
   - export CHANGELOG=$(git log $(git describe --abbrev=0 --tags "${TRAVIS_TAG}^")..$TRAVIS_TAG --pretty=format:'<li> <a href="http://github.com/liamg/aminal/commit/%H">view commit &bull;</a> %s</li> ' --reverse | while read line; do echo -n "$line "; done)
 deploy:
-  provider: releases
-  skip_cleanup: true
-  api_key:
-    secure: "hrBxJ2N8Ctti64Vf5uT9rsbo4TNloUuZZ7heusFtRaMoVDPT/k4xZctgyxV1q/5d4HLuh6yFILdJpwYKZv9JmA3+G2f154Jr6h6T/dw7Zh1HPjqaEn4/lkxYiTNNmZyCUjXfztC4xLmRwKhGz6PA0rUT44+6E2uQFqfovryVjhEcBaNBm7UhqENQ1UnFIK+otYt7sh0ZXcQuFOiPMax++wcBruC6Z9ZDtBkfLmUTJO0fP2DtkYtNZcZRJ8fG2XBagWDde6lbFyRRlXq04BMAxt8Jz8BvPFJo14/hEDjT8tv7R2I0Gy/pBTP0Ux/RwrzIdaEGTbBR5SpqQ+e5kWhjRZlO9Tv2prWYe9Psjx+FZpO5yr968BhkQz95Na53Oyb0IR4ItalA0ehx3euDDT9cWl/i96L733I/iCZaJ+15msJU06m1Kw6JkkmTOhI2iZTrpWpihyDJDUJNcW3UmzByHtOjElsHYAoUgiMKVe2fwJepIbIytiRz55AmNhqqP71qOIKCWZ6UoxBGD55+Wm4cSKL0nflQghZwcIpZFCU5V6ObRgO0IZJpohDBrAD1oZNNcu20EEKElFknEpJm22nVfD/1O64suT9HajVLDuLwdknpxDCy7cyZa5VcV3Pjyl/beY3LAuMbN3zR/alj0J0L4ciueowzC9sXNc4tAIL8jy4="
-  name: "Aminal $TRAVIS_TAG"
-  body: ${CHANGELOG}
-  file:
-    - bin/darwin/aminal-darwin-amd64
-    - bin/linux/aminal-linux-amd64
-    - bin/windows/aminal-windows-amd64.exe
-  on:
-    repo: liamg/aminal
-    tags: true
-    condition: "$TRAVIS_GO_VERSION =~ ^1\\.11"
+  - provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: "hrBxJ2N8Ctti64Vf5uT9rsbo4TNloUuZZ7heusFtRaMoVDPT/k4xZctgyxV1q/5d4HLuh6yFILdJpwYKZv9JmA3+G2f154Jr6h6T/dw7Zh1HPjqaEn4/lkxYiTNNmZyCUjXfztC4xLmRwKhGz6PA0rUT44+6E2uQFqfovryVjhEcBaNBm7UhqENQ1UnFIK+otYt7sh0ZXcQuFOiPMax++wcBruC6Z9ZDtBkfLmUTJO0fP2DtkYtNZcZRJ8fG2XBagWDde6lbFyRRlXq04BMAxt8Jz8BvPFJo14/hEDjT8tv7R2I0Gy/pBTP0Ux/RwrzIdaEGTbBR5SpqQ+e5kWhjRZlO9Tv2prWYe9Psjx+FZpO5yr968BhkQz95Na53Oyb0IR4ItalA0ehx3euDDT9cWl/i96L733I/iCZaJ+15msJU06m1Kw6JkkmTOhI2iZTrpWpihyDJDUJNcW3UmzByHtOjElsHYAoUgiMKVe2fwJepIbIytiRz55AmNhqqP71qOIKCWZ6UoxBGD55+Wm4cSKL0nflQghZwcIpZFCU5V6ObRgO0IZJpohDBrAD1oZNNcu20EEKElFknEpJm22nVfD/1O64suT9HajVLDuLwdknpxDCy7cyZa5VcV3Pjyl/beY3LAuMbN3zR/alj0J0L4ciueowzC9sXNc4tAIL8jy4="
+    name: "Aminal $TRAVIS_TAG"
+    body: ${CHANGELOG}
+    file:
+      - bin/darwin/aminal-darwin-amd64
+      - bin/linux/aminal-linux-amd64
+      - bin/windows/aminal-windows-amd64.exe
+    on:
+      repo: liamg/aminal
+      tags: true
+      condition: "$TRAVIS_GO_VERSION =~ ^1\\.11"
+  - provider: script
+    skip_cleanup: true
+    script: "./ci/push-nightly-tag.sh"
+    on:
+      all_branches: true
+      condition: "$TRAVIS_EVENT_TYPE == 'cron' && $TRAVIS_GO_VERSION =~ ^1\\.11 && $TRAVIS_OS_NAME == 'linux'"

--- a/ci/push-nightly-tag.sh
+++ b/ci/push-nightly-tag.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+echo "Starting nightly build deploy script..."
+MY_TAG="$( git describe --exact-match "$(git rev-parse HEAD)" 2>/dev/null )"
+if [ -z "$MY_TAG" ] ; then
+  echo "Tag for last commit is not found, going to try to push new nighlty build tag..."
+
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+
+  NEW_TAG="Nightly-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)"
+  git tag -a $NEW_TAG -m "Nightly Build Tag $NEW_TAG"
+
+  echo "New generated nightly build tag: $NEW_TAG"
+
+  git remote add origin-repo https://${GITHUB_TOKEN}@github.com/liamg/aminal.git > /dev/null 2>&1
+  git push origin-repo $NEW_TAG
+else
+  echo "Skipping nighly build tag generation. Last commit tag found:$MY_TAG"
+fi


### PR DESCRIPTION
## Description

Additional deploy `script` provider added to generate and push Nightly build tag into GitHub repo (new tag will trigger new GitHub release Travis run) on Travis Cron Job run.

Fixes #213 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on MaxRis/aminal fork. Sample of generated nightly build tag can be found [there](https://github.com/MaxRis/aminal/releases/tag/Nightly-2019-02-12-4370e32)
