### PR TITLE
Fix GL error GL_INVALID_OPERATION message (issue #153)

### DIFF
--- a/glfont/truetype.go
+++ b/glfont/truetype.go
@@ -53,12 +53,10 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale float32) (*Font, error)
 	vertAttrib := uint32(gl.GetAttribLocation(f.program, gl.Str("vert\x00")))
 	gl.EnableVertexAttribArray(vertAttrib)
 	gl.VertexAttribPointer(vertAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
-	defer gl.DisableVertexAttribArray(vertAttrib)
 
 	texCoordAttrib := uint32(gl.GetAttribLocation(f.program, gl.Str("vertTexCoord\x00")))
 	gl.EnableVertexAttribArray(texCoordAttrib)
 	gl.VertexAttribPointer(texCoordAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
-	defer gl.DisableVertexAttribArray(texCoordAttrib)
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	gl.BindVertexArray(0)


### PR DESCRIPTION
## Description

When run with `-debug` option on Windows, Aminal displays these messages in the log:

```
2019-01-16T21:34:03.331+0700    INFO    gui/gui.go:531  GL debug message: Error has been generated. GL error GL_INVALID_OPERATION in (null): (ID: 173538523) Generic error
2019-01-16T21:34:03.331+0700    INFO    gui/gui.go:531  GL debug message: Error has been generated. GL error GL_INVALID_OPERATION in (null): (ID: 173538523) Generic error
2019-01-16T21:34:03.344+0700    INFO    gui/gui.go:531  GL debug message: Error has been generated. GL error GL_INVALID_OPERATION in (null): (ID: 173538523) Generic error
2019-01-16T21:34:03.344+0700    INFO    gui/gui.go:531  GL debug message: Error has been generated. GL error GL_INVALID_OPERATION in (null): (ID: 173538523) Generic error
```
This PR eliminates those error messages.

Fixes #153

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The behavior described in the issue https://github.com/liamg/aminal/issues/153 should not appear anymore.

**Test Configuration**:
* OS: `Windows`
