### PR TITLE
#217 rectangular select and copy

### DIFF
--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -659,7 +659,7 @@ func TestSelectingChars(t *testing.T) {
 	b.StartSelection(2, 0, SelectionChar)
 	b.ExtendSelection(4, 1, true)
 
-	assert.Equal(t, "e quick brown\nfox j", b.GetSelectedText())
+	assert.Equal(t, "e quick brown\nfox j", b.GetSelectedText(SelectionRegionNormal))
 }
 
 func TestSelectingWordsDown(t *testing.T) {
@@ -668,7 +668,7 @@ func TestSelectingWordsDown(t *testing.T) {
 	b.StartSelection(6, 1, SelectionWord)
 	b.ExtendSelection(5, 2, true)
 
-	assert.Equal(t, "jumps over\nthe lazy", b.GetSelectedText())
+	assert.Equal(t, "jumps over\nthe lazy", b.GetSelectedText(SelectionRegionNormal))
 }
 
 func TestSelectingWordsUp(t *testing.T) {
@@ -677,7 +677,7 @@ func TestSelectingWordsUp(t *testing.T) {
 	b.StartSelection(5, 2, SelectionWord)
 	b.ExtendSelection(6, 1, true)
 
-	assert.Equal(t, "jumps over\nthe lazy", b.GetSelectedText())
+	assert.Equal(t, "jumps over\nthe lazy", b.GetSelectedText(SelectionRegionNormal))
 }
 
 func TestSelectingLinesDown(t *testing.T) {
@@ -686,7 +686,7 @@ func TestSelectingLinesDown(t *testing.T) {
 	b.StartSelection(6, 1, SelectionLine)
 	b.ExtendSelection(4, 2, true)
 
-	assert.Equal(t, "fox jumps over\nthe lazy dog", b.GetSelectedText())
+	assert.Equal(t, "fox jumps over\nthe lazy dog", b.GetSelectedText(SelectionRegionNormal))
 }
 
 func TestSelectingLineUp(t *testing.T) {
@@ -695,7 +695,7 @@ func TestSelectingLineUp(t *testing.T) {
 	b.StartSelection(8, 2, SelectionLine)
 	b.ExtendSelection(3, 1, true)
 
-	assert.Equal(t, "fox jumps over\nthe lazy dog", b.GetSelectedText())
+	assert.Equal(t, "fox jumps over\nthe lazy dog", b.GetSelectedText(SelectionRegionNormal))
 }
 
 func TestSelectingAfterText(t *testing.T) {
@@ -704,7 +704,7 @@ func TestSelectingAfterText(t *testing.T) {
 	b.StartSelection(6, 3, SelectionChar)
 	b.ExtendSelection(6, 3, true)
 
-	start, end := b.getActualSelection()
+	start, end := b.getActualSelection(SelectionRegionNormal)
 
 	assert.Equal(t, start.Col, 0)
 	assert.Equal(t, start.Line, 3)

--- a/gui/actions.go
+++ b/gui/actions.go
@@ -18,7 +18,7 @@ var actionMap = map[config.UserAction]func(gui *GUI){
 }
 
 func actionCopy(gui *GUI) {
-	selectedText := gui.terminal.ActiveBuffer().GetSelectedText()
+	selectedText := gui.terminal.ActiveBuffer().GetSelectedText(gui.selectionRegionMode)
 
 	if selectedText != "" {
 		gui.window.SetClipboardString(selectedText)
@@ -37,7 +37,7 @@ func actionToggleDebug(gui *GUI) {
 }
 
 func actionSearchSelection(gui *GUI) {
-	keywords := gui.terminal.ActiveBuffer().GetSelectedText()
+	keywords := gui.terminal.ActiveBuffer().GetSelectedText(gui.selectionRegionMode)
 	if keywords != "" && gui.config.SearchURL != "" && strings.Contains(gui.config.SearchURL, "$QUERY") {
 		gui.launchTarget(fmt.Sprintf(strings.Replace(gui.config.SearchURL, "$QUERY", "%s", 1), url.QueryEscape(keywords)))
 	}

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -58,6 +58,7 @@ type GUI struct {
 	leftClickCount                  int // number of clicks in a serie - single click, double click, or triple click
 	mouseMovedAfterSelectionStarted bool
 	internalResize                  bool
+	selectionRegionMode             buffer.SelectionRegionMode
 }
 
 func Min(x, y int) int {
@@ -488,7 +489,7 @@ func (gui *GUI) redraw() {
 					cursor = cx == uint(x) && cy == uint(y)
 				}
 
-				if gui.terminal.ActiveBuffer().InSelection(uint16(x), uint16(y)) {
+				if gui.terminal.ActiveBuffer().InSelection(uint16(x), uint16(y), gui.selectionRegionMode) {
 					colour = &gui.config.ColourScheme.Selection
 				} else {
 					colour = nil

--- a/gui/input.go
+++ b/gui/input.go
@@ -57,10 +57,6 @@ func (gui *GUI) updateSelectionMode(mods glfw.ModifierKey) {
 }
 
 func (gui *GUI) key(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-	if action == glfw.Press || action == glfw.Release {
-		gui.updateSelectionMode(mods)
-	}
-
 	if action == glfw.Repeat || action == glfw.Press {
 
 		if gui.overlay != nil {

--- a/gui/input.go
+++ b/gui/input.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/go-gl/glfw/v3.2/glfw"
+	"github.com/liamg/aminal/buffer"
 )
 
 // send typed runes straight through to the pty
@@ -44,7 +45,21 @@ func getModStr(mods glfw.ModifierKey) string {
 	return ""
 }
 
+func (gui *GUI) updateSelectionMode(mods glfw.ModifierKey) {
+	mode := buffer.SelectionRegionNormal
+	if modsPressed(mods, glfw.ModAlt) {
+		mode = buffer.SelectionRegionRectangular
+	}
+	if gui.selectionRegionMode != mode {
+		gui.selectionRegionMode = mode
+		gui.terminal.SetDirty()
+	}
+}
+
 func (gui *GUI) key(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
+	if action == glfw.Press || action == glfw.Release {
+		gui.updateSelectionMode(mods)
+	}
 
 	if action == glfw.Repeat || action == glfw.Press {
 

--- a/gui/mouse.go
+++ b/gui/mouse.go
@@ -143,7 +143,7 @@ func (gui *GUI) mouseButtonCallback(w *glfw.Window, button glfw.MouseButton, act
 			gui.mouseDown = true
 
 			if gui.terminal.GetMouseMode() != terminal.MouseModeButtonEvent {
-				gui.handleSelectionButtonPress(x, y)
+				gui.handleSelectionButtonPress(x, y, mod)
 			}
 		} else if action == glfw.Release {
 			gui.mouseDown = false
@@ -255,9 +255,10 @@ func (gui *GUI) mouseButtonCallback(w *glfw.Window, button glfw.MouseButton, act
 
 }
 
-func (gui *GUI) handleSelectionButtonPress(x uint16, y uint16) {
+func (gui *GUI) handleSelectionButtonPress(x uint16, y uint16, mod glfw.ModifierKey) {
 	activeBuffer := gui.terminal.ActiveBuffer()
 	clickCount := gui.updateLeftClickCount(x, y)
+	gui.updateSelectionMode(mod)
 	switch clickCount {
 	case 1:
 		activeBuffer.StartSelection(x, y, buffer.SelectionChar)
@@ -282,7 +283,7 @@ func (gui *GUI) handleSelectionButtonRelease(x uint16, y uint16) {
 	// Do copy to clipboard *or* open URL, but not both.
 	handled := false
 	if gui.config.CopyAndPasteWithMouse {
-		selectedText := activeBuffer.GetSelectedText()
+		selectedText := activeBuffer.GetSelectedText(gui.selectionRegionMode)
 		if selectedText != "" {
 			gui.window.SetClipboardString(selectedText)
 			handled = true


### PR DESCRIPTION
## Description

Pressing 'Alt' would make the selection region rectangular

Fixes # 217

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Start selection with mouse.
Press left 'Alt'.
The selection region becomes rectangular

**Test Configuration**:
* OS: Windows
* OS version: 1809
* Go version: 1.10.4

