### PR TITLE
Add option for generating CPU profile

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ func getConfig() *config.Config {
 	shell := ""
 	debugMode := false
 	slomo := false
+	cpuProfile := ""
 
 	if flag.Parsed() == false {
 		flag.BoolVar(&showVersion, "version", showVersion, "Output version information")
@@ -35,6 +36,7 @@ func getConfig() *config.Config {
 		flag.StringVar(&shell, "shell", shell, "Specify the shell to use")
 		flag.BoolVar(&debugMode, "debug", debugMode, "Enable debug logging")
 		flag.BoolVar(&slomo, "slomo", slomo, "Render in slow motion (useful for debugging)")
+		flag.StringVar(&cpuProfile, "cpuprofile", cpuProfile, "Write a CPU profile to this file")
 
 		flag.Parse() // actual parsing and fetching flags from the command line
 	}
@@ -67,6 +69,10 @@ func getConfig() *config.Config {
 
 	if actuallyProvidedFlags["slomo"] {
 		conf.Slomo = slomo
+	}
+
+	if actuallyProvidedFlags["cpuprofile"] {
+		conf.CPUProfile = cpuProfile
 	}
 
 	return conf

--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,6 @@ import (
 )
 
 type Config struct {
-	DebugMode             bool             `toml:"debug"`
-	Slomo                 bool             `toml:"slomo"`
 	ColourScheme          ColourScheme     `toml:"colours"`
 	DPIScale              float32          `toml:"dpi-scale"`
 	Shell                 string           `toml:"shell"`
@@ -16,6 +14,11 @@ type Config struct {
 	SearchURL             string           `toml:"search_url"`
 	MaxLines              uint64           `toml:"max_lines"`
 	CopyAndPasteWithMouse bool             `toml:"copy_and_paste_with_mouse"`
+
+	// Developer options.
+	DebugMode  bool   `toml:"debug"`
+	Slomo      bool   `toml:"slomo"`
+	CPUProfile string `toml:"cpu_profile"`
 }
 
 type KeyMappingConfig map[string]string

--- a/main.go
+++ b/main.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
 	"github.com/liamg/aminal/gui"
 	"github.com/liamg/aminal/platform"
 	"github.com/liamg/aminal/terminal"
 	"github.com/riywo/loginshell"
-	"os"
-	"runtime"
 )
 
 type callback func(terminal *terminal.Terminal, g *gui.GUI)
@@ -29,8 +32,13 @@ func initialize(unitTestfunc callback) {
 	}
 	defer logger.Sync()
 
-	logger.Infof("Allocating pty...")
+	if conf.CPUProfile != "" {
+		logger.Infof("Starting CPU profiling...")
+		stop := startCPUProf(conf.CPUProfile)
+		defer stop()
+	}
 
+	logger.Infof("Allocating pty...")
 	pty, err := platform.NewPty(80, 25)
 	if err != nil {
 		logger.Fatalf("Failed to allocate pty: %s", err)
@@ -77,4 +85,13 @@ func initialize(unitTestfunc callback) {
 	if err := g.Render(); err != nil {
 		logger.Fatalf("Render error: %s", err)
 	}
+}
+
+func startCPUProf(filename string) func() {
+	profileFile, err := os.Create(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pprof.StartCPUProfile(profileFile)
+	return pprof.StopCPUProfile
 }


### PR DESCRIPTION
## Description

This adds a `--cpuprofile` command line option which causes aminal to generate a Go CPU profile file. This is useful for investigating performance issues.

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked that CPU profile is generated when `--cpuprofile` is passed and isn't generated when the argument isn't passed.

**Test Configuration**:
* OS: Linux
* OS version: Ubuntu 18.04
* Go version: 1.12

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
