### PR TITLE
Decouple vttest tests from user's config

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,13 @@ func getActuallyProvidedFlags() map[string]bool {
 	return result
 }
 
+func maybeGetConfig(override *config.Config) *config.Config {
+	if override != nil {
+		return override
+	}
+	return getConfig()
+}
+
 func getConfig() *config.Config {
 	showVersion := false
 	ignoreConfig := false

--- a/config.go
+++ b/config.go
@@ -53,7 +53,7 @@ func getConfig() *config.Config {
 
 	var conf *config.Config
 	if ignoreConfig {
-		conf = &config.DefaultConfig
+		conf = config.DefaultConfig()
 	} else {
 		conf = loadConfigFile()
 	}
@@ -83,12 +83,12 @@ func loadConfigFile() *config.Config {
 	usr, err := user.Current()
 	if err != nil {
 		fmt.Printf("Failed to get current user information: %s\n", err)
-		return &config.DefaultConfig
+		return config.DefaultConfig()
 	}
 
 	home := usr.HomeDir
 	if home == "" {
-		return &config.DefaultConfig
+		return config.DefaultConfig()
 	}
 
 	places := []string{}
@@ -111,7 +111,7 @@ func loadConfigFile() *config.Config {
 		}
 	}
 
-	if b, err := config.DefaultConfig.Encode(); err != nil {
+	if b, err := config.DefaultConfig().Encode(); err != nil {
 		fmt.Printf("Failed to encode config file: %s\n", err)
 	} else {
 		err = os.MkdirAll(filepath.Dir(places[0]), 0744)
@@ -124,5 +124,5 @@ func loadConfigFile() *config.Config {
 		}
 	}
 
-	return &config.DefaultConfig
+	return config.DefaultConfig()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,12 +24,12 @@ type Config struct {
 type KeyMappingConfig map[string]string
 
 func Parse(data []byte) (*Config, error) {
-	c := DefaultConfig
-	err := toml.Unmarshal(data, &c)
+	c := DefaultConfig()
+	err := toml.Unmarshal(data, c)
 	if c.KeyMapping == nil {
 		c.KeyMapping = KeyMappingConfig(map[string]string{})
 	}
-	return &c, err
+	return c, err
 }
 
 func (c *Config) Encode() ([]byte, error) {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -2,52 +2,50 @@ package config
 
 import "runtime"
 
-var DefaultConfig = Config{
-	DebugMode: false,
-	ColourScheme: ColourScheme{
-		Cursor:       strToColourNoErr("#e8dfd6"),
-		Foreground:   strToColourNoErr("#e8dfd6"),
-		Background:   strToColourNoErr("#021b21"),
-		Black:        strToColourNoErr("#000000"),
-		Red:          strToColourNoErr("#800000"),
-		Green:        strToColourNoErr("#008000"),
-		Yellow:       strToColourNoErr("#808000"),
-		Blue:         strToColourNoErr("#000080"),
-		Magenta:      strToColourNoErr("#800080"),
-		Cyan:         strToColourNoErr("#008080"),
-		LightGrey:    strToColourNoErr("#f2f2f2"),
-		DarkGrey:     strToColourNoErr("#808080"),
-		LightRed:     strToColourNoErr("#ff0000"),
-		LightGreen:   strToColourNoErr("#00ff00"),
-		LightYellow:  strToColourNoErr("#ffff00"),
-		LightBlue:    strToColourNoErr("#0000ff"),
-		LightMagenta: strToColourNoErr("#ff00ff"),
-		LightCyan:    strToColourNoErr("#00ffff"),
-		White:        strToColourNoErr("#ffffff"),
-		Selection:    strToColourNoErr("#333366"),
-	},
-	KeyMapping:            KeyMappingConfig(map[string]string{}),
-	SearchURL:             "https://www.google.com/search?q=$QUERY",
-	MaxLines:              1000,
-	CopyAndPasteWithMouse: true,
-}
-
-func init() {
-	DefaultConfig.KeyMapping[string(ActionCopy)] = addMod("c")
-	DefaultConfig.KeyMapping[string(ActionPaste)] = addMod("v")
-	DefaultConfig.KeyMapping[string(ActionSearch)] = addMod("g")
-	DefaultConfig.KeyMapping[string(ActionToggleDebug)] = addMod("d")
-	DefaultConfig.KeyMapping[string(ActionToggleSlomo)] = addMod(";")
-	DefaultConfig.KeyMapping[string(ActionReportBug)] = addMod("r")
-	DefaultConfig.KeyMapping[string(ActionBufferClear)] = addMod("k")
+func DefaultConfig() *Config {
+	return &Config{
+		DebugMode: false,
+		ColourScheme: ColourScheme{
+			Cursor:       strToColourNoErr("#e8dfd6"),
+			Foreground:   strToColourNoErr("#e8dfd6"),
+			Background:   strToColourNoErr("#021b21"),
+			Black:        strToColourNoErr("#000000"),
+			Red:          strToColourNoErr("#800000"),
+			Green:        strToColourNoErr("#008000"),
+			Yellow:       strToColourNoErr("#808000"),
+			Blue:         strToColourNoErr("#000080"),
+			Magenta:      strToColourNoErr("#800080"),
+			Cyan:         strToColourNoErr("#008080"),
+			LightGrey:    strToColourNoErr("#f2f2f2"),
+			DarkGrey:     strToColourNoErr("#808080"),
+			LightRed:     strToColourNoErr("#ff0000"),
+			LightGreen:   strToColourNoErr("#00ff00"),
+			LightYellow:  strToColourNoErr("#ffff00"),
+			LightBlue:    strToColourNoErr("#0000ff"),
+			LightMagenta: strToColourNoErr("#ff00ff"),
+			LightCyan:    strToColourNoErr("#00ffff"),
+			White:        strToColourNoErr("#ffffff"),
+			Selection:    strToColourNoErr("#333366"),
+		},
+		KeyMapping: KeyMappingConfig(map[string]string{
+			string(ActionCopy):        addMod("c"),
+			string(ActionPaste):       addMod("v"),
+			string(ActionSearch):      addMod("g"),
+			string(ActionToggleDebug): addMod("d"),
+			string(ActionToggleSlomo): addMod(";"),
+			string(ActionReportBug):   addMod("r"),
+			string(ActionBufferClear): addMod("k"),
+		}),
+		SearchURL:             "https://www.google.com/search?q=$QUERY",
+		MaxLines:              1000,
+		CopyAndPasteWithMouse: true,
+	}
 }
 
 func addMod(keys string) string {
 	standardMod := "ctrl + shift + "
-
 	if runtime.GOOS == "darwin" {
 		standardMod = "super + "
 	}
-
 	return standardMod + keys
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 
+	"github.com/liamg/aminal/config"
 	"github.com/liamg/aminal/gui"
 	"github.com/liamg/aminal/platform"
 	"github.com/liamg/aminal/terminal"
@@ -20,11 +21,12 @@ func init() {
 }
 
 func main() {
-	initialize(nil)
+	initialize(nil, nil)
 }
 
-func initialize(unitTestfunc callback) {
-	conf := getConfig()
+func initialize(unitTestfunc callback, configOverride *config.Config) {
+	conf := maybeGetConfig(configOverride)
+
 	logger, err := getLogger(conf)
 	if err != nil {
 		fmt.Printf("Failed to create logger: %s\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -6,10 +6,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/liamg/aminal/config"
 	"github.com/liamg/aminal/gui"
 	"github.com/liamg/aminal/terminal"
 
@@ -123,7 +125,7 @@ func TestCursorMovement(t *testing.T) {
 			g.Close()
 		}
 
-		initialize(testFunc)
+		initialize(testFunc, testConfig())
 	})
 }
 
@@ -159,7 +161,7 @@ func TestScreenFeatures(t *testing.T) {
 			g.Close()
 		}
 
-		initialize(testFunc)
+		initialize(testFunc, testConfig())
 	})
 }
 
@@ -184,11 +186,22 @@ func TestSixel(t *testing.T) {
 			g.Close()
 		}
 
-		initialize(testFunc)
+		initialize(testFunc, testConfig())
 	})
 }
 
 // Last Test should terminate main goroutine since it's infinity looped to execute others GUI tests in main goroutine
 func TestExit(t *testing.T) {
 	os.Exit(0)
+}
+
+func testConfig() *config.Config {
+	c := config.DefaultConfig()
+
+	// Use a vanilla shell on POSIX to help ensure consistency.
+	if runtime.GOOS != "windows" {
+		c.Shell = "/bin/sh"
+	}
+
+	return c
 }


### PR DESCRIPTION
## Description

The screen capture tests were failing on my machine because the screen capture based vttest tests were using my personal config in ~/.config/aminal/config.toml. This had different colours and a fixed
DPI scaling factor which mean the screen captures didn't match.

The sixel tests were also failing because my login shell is a customised zsh.

A static test config is now passed by the vttest tests and the shell is set to "/bin/sh" on Linux, OSX etc to help avoid problems due to differences between shells and shell configs.

This PR also includes a change which makes DefaultConfig a little safer. Instead of having a global mutable DefaultConfig which might be changed by anything during run/test time turn DefaultConfig into a function which returns a fresh DefaultConfig. This is safer and more convenient.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`xvfb-run --server-args="-screen 0 1024x768x24" make test` now works reliably on my test machines when it didn't before.

**Test Configuration**:
* OS: Linux
* OS version: Ubuntu 18.04
* Go version: 1.11.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
