### PR TITLE
Add running gofmt to the PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @liamg
+* @liamg @MaxRis

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 ## Checklist:
 
+- [ ] I have run `gofmt` on the project
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas


### PR DESCRIPTION
## Description

Just a minor change - I propose to add running `gofmt` to the PR template checklist because committers (at least personally myself) constantly forgetting to do that.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
