### PR TITLE
No newlines when copying

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -215,7 +215,7 @@ func (buffer *Buffer) GetSelectedText(selectionRegionMode SelectionRegionMode) s
 		maxX := int(buffer.terminalState.viewWidth) - 1
 		if row == start.Line {
 			minX = start.Col
-		} else if !line.wrapped {
+		} else if !line.wrapped && !line.nobreak {
 			builder.WriteString("\n")
 		}
 		if row == end.Line {
@@ -695,6 +695,7 @@ func (buffer *Buffer) Write(runes ...rune) {
 				buffer.NewLineEx(true)
 
 				newLine := buffer.getCurrentLine()
+				newLine.setNoBreak(true)
 				if len(newLine.cells) == 0 {
 					newLine.Append(buffer.terminalState.DefaultCell(true))
 				}

--- a/buffer/line.go
+++ b/buffer/line.go
@@ -6,12 +6,14 @@ import (
 
 type Line struct {
 	wrapped bool // whether line was wrapped onto from the previous one
+	nobreak bool // true if no line break at the beginning of the line
 	cells   []Cell
 }
 
 func newLine() Line {
 	return Line{
 		wrapped: false,
+		nobreak: false,
 		cells:   []Cell{},
 	}
 }
@@ -43,6 +45,10 @@ func (line *Line) Cleanse() {
 
 func (line *Line) setWrapped(wrapped bool) {
 	line.wrapped = wrapped
+}
+
+func (line *Line) setNoBreak(nobreak bool) {
+	line.nobreak = nobreak
 }
 
 func (line *Line) String() string {


### PR DESCRIPTION
## Description

Aminal should not insert newlines in copied data if they were not printed to the terminal (i.e. wrapped automatically)

Fixes #249 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created a file with lines larger then console width, then selected the text with mouse

**Test Configuration**:
* OS: Ubuntu
* OS version: 18.04
* Go version: 1.11

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
