### PR TITLE
Solve intermittent build errors

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -808,24 +808,27 @@ func (gui *GUI) SwapBuffers() {
 	gui.window.SwapBuffers()
 }
 
-func (gui *GUI) Screenshot(path string) {
+func (gui *GUI) Screenshot(path string) error {
 	x, y := gui.window.GetPos()
 	w, h := gui.window.GetSize()
 
 	img, err := screenshot.CaptureRect(image.Rectangle{Min: image.Point{X: x, Y: y},
 		Max: image.Point{X: x + w, Y: y + h}})
 	if err != nil {
-		panic(err)
+		return err
 	}
 	file, err := os.Create(path)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer file.Close()
 	err = png.Encode(file, img)
 	if err != nil {
-		panic(err)
+		os.Remove(path)
+		return err
 	}
+	
+	return nil
 }
 
 func (gui *GUI) windowPosChangeCallback(w *glfw.Window, xpos int, ypos int) {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func initialize(unitTestfunc callback, configOverride *config.Config) {
 	guestProcess, err := pty.CreateGuestProcess(shellStr)
 	if err != nil {
 		pty.Close()
-		logger.Fatalf("Failed to start your shell \"%s\": %s", shellStr, err)
+		logger.Fatalf("Failed to start your shell %q: %s", shellStr, err)
 	}
 	defer guestProcess.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,15 +5,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/carlogit/phash"
-	"github.com/liamg/aminal/config"
-	"github.com/liamg/aminal/gui"
-	"github.com/liamg/aminal/terminal"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/carlogit/phash"
+	"github.com/liamg/aminal/config"
+	"github.com/liamg/aminal/gui"
+	"github.com/liamg/aminal/terminal"
 )
 
 var termRef *terminal.Terminal
@@ -76,7 +77,11 @@ func enter(terminal *terminal.Terminal) {
 func validateScreen(img string, waitForChange bool) {
 	fmt.Printf("taking screenshot: %s and comparing...", img)
 
-	guiRef.Screenshot(img)
+	err := guiRef.Screenshot(img)
+	if err != nil {
+		panic(err)
+	}
+
 	compareImages(strings.Join([]string{"vttest/", img}, ""), img)
 
 	fmt.Printf("compare OK\n")
@@ -89,7 +94,10 @@ func validateScreen(img string, waitForChange bool) {
 		for {
 			sleep()
 			actualScren := "temp.png"
-			guiRef.Screenshot(actualScren)
+			err = guiRef.Screenshot(actualScren)
+			if err != nil {
+				panic(err)
+			}
 			distance := imagesAreEqual(actualScren, img)
 			if distance != 0 {
 				break

--- a/main_test.go
+++ b/main_test.go
@@ -5,17 +5,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/carlogit/phash"
+	"github.com/liamg/aminal/config"
+	"github.com/liamg/aminal/gui"
+	"github.com/liamg/aminal/terminal"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/liamg/aminal/config"
-	"github.com/liamg/aminal/gui"
-	"github.com/liamg/aminal/terminal"
-
-	"github.com/carlogit/phash"
 )
 
 var termRef *terminal.Terminal
@@ -47,10 +45,14 @@ func hash(path string) string {
 	return imageHash
 }
 
+func imagesAreEqual(expected string, actual string) int {
+	expectedHash := hash(expected)
+	actualHash := hash(actual)
+	return phash.GetDistance(expectedHash, actualHash)
+}
+
 func compareImages(expected string, actual string) {
-	template := hash(expected)
-	screen := hash(actual)
-	distance := phash.GetDistance(template, screen)
+	distance := imagesAreEqual(expected, actual)
 	if distance != 0 {
 		os.Exit(terminate(fmt.Sprintf("Screenshot \"%s\" doesn't match expected image \"%s\". Distance of hashes difference: %d\n",
 			actual, expected, distance)))
@@ -58,19 +60,48 @@ func compareImages(expected string, actual string) {
 }
 
 func send(terminal *terminal.Terminal, cmd string) {
-	terminal.Write([]byte(cmd))
+	err := terminal.Write([]byte(cmd))
+	if err != nil {
+		panic(err)
+	}
 }
 
 func enter(terminal *terminal.Terminal) {
-	terminal.Write([]byte("\n"))
+	err := terminal.Write([]byte("\n"))
+	if err != nil {
+		panic(err)
+	}
 }
 
-func validateScreen(img string) {
+func validateScreen(img string, waitForChange bool) {
+	fmt.Printf("taking screenshot: %s and comparing...", img)
+
 	guiRef.Screenshot(img)
 	compareImages(strings.Join([]string{"vttest/", img}, ""), img)
 
+	fmt.Printf("compare OK\n")
+
 	enter(termRef)
-	sleep()
+
+	if waitForChange {
+		fmt.Print("Waiting for screen change...")
+		attempts := 10
+		for {
+			sleep()
+			actualScren := "temp.png"
+			guiRef.Screenshot(actualScren)
+			distance := imagesAreEqual(actualScren, img)
+			if distance != 0 {
+				break
+			}
+			fmt.Printf(" %d", attempts)
+			attempts--
+			if attempts <= 0 {
+				break
+			}
+		}
+		fmt.Print("done\n")
+	}
 }
 
 func TestMain(m *testing.M) {
@@ -115,12 +146,12 @@ func TestCursorMovement(t *testing.T) {
 				os.Exit(terminate(fmt.Sprintf("ActiveBuffer doesn't match vttest template vttest/test-cursor-movement-1")))
 			}
 
-			validateScreen("test-cursor-movement-1.png")
-			validateScreen("test-cursor-movement-2.png")
-			validateScreen("test-cursor-movement-3.png")
-			validateScreen("test-cursor-movement-4.png")
-			validateScreen("test-cursor-movement-5.png")
-			validateScreen("test-cursor-movement-6.png")
+			validateScreen("test-cursor-movement-1.png", true)
+			validateScreen("test-cursor-movement-2.png", true)
+			validateScreen("test-cursor-movement-3.png", true)
+			validateScreen("test-cursor-movement-4.png", true)
+			validateScreen("test-cursor-movement-5.png", true)
+			validateScreen("test-cursor-movement-6.png", false)
 
 			g.Close()
 		}
@@ -142,21 +173,21 @@ func TestScreenFeatures(t *testing.T) {
 			send(term, "2\n")
 			sleep()
 
-			validateScreen("test-screen-features-1.png")
-			validateScreen("test-screen-features-2.png")
-			validateScreen("test-screen-features-3.png")
-			validateScreen("test-screen-features-4.png")
-			validateScreen("test-screen-features-5.png")
-			validateScreen("test-screen-features-6.png")
-			validateScreen("test-screen-features-7.png")
-			validateScreen("test-screen-features-8.png")
-			validateScreen("test-screen-features-9.png")
-			validateScreen("test-screen-features-10.png")
-			validateScreen("test-screen-features-11.png")
-			validateScreen("test-screen-features-12.png")
-			validateScreen("test-screen-features-13.png")
-			validateScreen("test-screen-features-14.png")
-			validateScreen("test-screen-features-15.png")
+			validateScreen("test-screen-features-1.png", true)
+			validateScreen("test-screen-features-2.png", true)
+			validateScreen("test-screen-features-3.png", true)
+			validateScreen("test-screen-features-4.png", true)
+			validateScreen("test-screen-features-5.png", true)
+			validateScreen("test-screen-features-6.png", true)
+			validateScreen("test-screen-features-7.png", true)
+			validateScreen("test-screen-features-8.png", true)
+			validateScreen("test-screen-features-9.png", true)
+			validateScreen("test-screen-features-10.png", true)
+			validateScreen("test-screen-features-11.png", true)
+			validateScreen("test-screen-features-12.png", true)
+			validateScreen("test-screen-features-13.png", true)
+			validateScreen("test-screen-features-14.png", true)
+			validateScreen("test-screen-features-15.png", false)
 
 			g.Close()
 		}
@@ -178,10 +209,9 @@ func TestSixel(t *testing.T) {
 			send(term, "clear\n")
 			sleep()
 			send(term, "cat example.sixel\n")
-			sleep(4)
+			sleep(10) // Displaying SIXEL graphics *sometimes* takes long time. Excessive synchronization???
 
-			guiRef.Screenshot("test-sixel.png")
-			validateScreen("test-sixel.png")
+			validateScreen("test-sixel.png", false)
 
 			g.Close()
 		}


### PR DESCRIPTION
## Description

This PR eliminates the intermittent build errors have been started to appear recently.
The screenshot-based tests were intermittently failing because sometimes it took too much time for Aminal to refresh its screen after sending Enter key. Because the timeout is not constant (up to 10 seconds on my machine), I've decided to wait until the screen changes instead of just sleeping. That made the tests more robust.

Also, I added waiting for the `waker()` function to end at the end of the `Render()` function, because consecutive tests were interfering with each other.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run tests with `go test -v .\...` and `go test -v .` many times while the system is under load. There should be no errors.

**Test Configuration**:
* OS: `Debian stretch`
