### PR TITLE
Smarter URL/URI parsing

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -109,7 +109,7 @@ func (buffer *Buffer) GetURLAtPosition(col uint16, viewRow uint16) string {
 		if protocolMode && !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z') {
 			break
 		}
-		candidate = fmt.Sprintf("%c%s", cell.Rune(), candidate)
+		candidate = fmt.Sprintf("%c%s", c, candidate)
 		if !protocolMode && c == ':' {
 			protocolMode = strings.Contains(candidate, "://")
 		}

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -76,23 +76,13 @@ func (buffer *Buffer) GetURLAtPosition(col uint16, viewRow uint16) string {
 	row := buffer.convertViewLineToRawLine((viewRow)) - uint64(buffer.terminalState.scrollLinesFromBottom)
 
 	cell := buffer.GetRawCell(col, row)
-	if cell == nil || cell.Rune() == 0x00 {
+	if cell == nil || isRuneURLSelectionMarker(cell.Rune()) {
 		return ""
 	}
 
-	candidate := ""
+	candidate := string(cell.Rune())
 
-	for i := col; i >= uint16(0); i-- {
-		cell := buffer.GetRawCell(i, row)
-		if cell == nil {
-			break
-		}
-		if isRuneURLSelectionMarker(cell.Rune()) {
-			break
-		}
-		candidate = fmt.Sprintf("%c%s", cell.Rune(), candidate)
-	}
-
+	// First, move forward
 	for i := col + 1; i < buffer.terminalState.viewWidth; i++ {
 		cell := buffer.GetRawCell(i, row)
 		if cell == nil {
@@ -102,6 +92,27 @@ func (buffer *Buffer) GetURLAtPosition(col uint16, viewRow uint16) string {
 			break
 		}
 		candidate = fmt.Sprintf("%s%c", candidate, cell.Rune())
+	}
+
+	// Move backwards
+	protocolMode := strings.Contains(candidate, "://")
+	for i := col - 1; i >= uint16(0); i-- {
+		cell := buffer.GetRawCell(i, row)
+		if cell == nil {
+			break
+		}
+		c := cell.Rune()
+		if isRuneURLSelectionMarker(c) {
+			break
+		}
+		// if we're tracking left of :// we want to break on any non-Latin character
+		if protocolMode && !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z') {
+			break
+		}
+		candidate = fmt.Sprintf("%c%s", cell.Rune(), candidate)
+		if !protocolMode && c == ':' {
+			protocolMode = strings.Contains(candidate, "://")
+		}
 	}
 
 	if candidate == "" || candidate[0] == '/' {


### PR DESCRIPTION
## Description

Previously, a text `prompt>ssh://somewhere` was parsed incorrectly whene detecting URL on mouse hover/click. Resulting URL was `prompt>ssh://somewhere`.
Now that we stop selecting URL on any non-Latin character left of `://`, the result will be `ssh://somewhere`

Fixes # 205 (partially)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On Windows, the prompt terminates with `>` character. Type `ssh://somewhere` right after the prompt. Click on it. It should redirect you to the correct site.

**Test Configuration**:
* OS: Windows
* OS version: 1809
* Go version: 1.11
