### PR TITLE
#116 URXVT extended mouse mode support

### DIFF
--- a/gui/mouse.go
+++ b/gui/mouse.go
@@ -333,13 +333,16 @@ func (gui *GUI) emitButtonEventToTerminal(tx int, ty int, button glfw.MouseButto
 	gui.prevMotionTY = ty
 
 	var packet string
-	if ext == terminal.MouseExtSGR {
+	switch ext {
+	case terminal.MouseExtSGR:
 		final := 'M'
 		if release {
 			final = 'm'
 		}
 		packet = fmt.Sprintf("\x1b[<%d;%d;%d%c", b, tx, ty, final)
-	} else {
+	case terminal.MouseExtURXVT:
+		packet = fmt.Sprintf("\x1b[%d;%d;%dM", b+32, tx, ty)
+	default:
 		packet = fmt.Sprintf("\x1b[M%c%c%c", (rune(b + 32)), (rune(tx + 32)), (rune(ty + 32)))
 	}
 	gui.logger.Infof("Sending mouse packet: '%v'", packet)

--- a/terminal/modes.go
+++ b/terminal/modes.go
@@ -172,6 +172,14 @@ func csiSetMode(modeStr string, enabled bool, terminal *Terminal) error {
 			terminal.logger.Infof("Turning off SGR ext mouse mode")
 			terminal.SetMouseExtMode(MouseExtNone)
 		}
+	case "?1015":
+		if enabled {
+			terminal.logger.Infof("Turning on URXVT ext mouse mode")
+			terminal.SetMouseExtMode(MouseExtURXVT)
+		} else {
+			terminal.logger.Infof("Turning off URXVT ext mouse mode")
+			terminal.SetMouseExtMode(MouseExtNone)
+		}
 	case "?1048":
 		if enabled {
 			terminal.ActiveBuffer().SaveCursor()

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -31,6 +31,7 @@ const (
 	MouseExtNone MouseExtMode = iota
 	MouseExtUTF
 	MouseExtSGR
+	MouseExtURXVT
 )
 
 type WindowManipulationInterface interface {


### PR DESCRIPTION
## Description

URXVT mouse encoding is now supported.

Fixes # 116

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Running `gotop` should not result in error messages

**Test Configuration**:
* OS: Ubutnu
* OS version: 18.04
* Go version: 1.11
