### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/buffer/terminal_state.go
+++ b/buffer/terminal_state.go
@@ -20,7 +20,7 @@ type TerminalState struct {
 	CurrentCharset        int              // active charset index in Charsets array, valid values are 0 or 1
 }
 
-// NewTerminalMode creates a new terminal state
+// NewTerminalState creates a new terminal state
 func NewTerminalState(viewCols uint16, viewLines uint16, attr CellAttributes, maxLines uint64) *TerminalState {
 	b := &TerminalState{
 		cursorX:      0,


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?