### PR TITLE
Added options for setting GOMAXPROCS and profiling output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ dpi-scale = 0.0             # Override DPI scale. Defaults to 0.0 (let Aminal de
 | `--debug`         | Enable debug mode, with debug logging and debug info terminal overlay.
 | `--slomo`         | Enable slomo mode, delay the handling of each incoming byte (or escape sequence) from the pty by 100ms. Useful for debugging.
 | `--shell [shell]` | Use the specified shell program instead of the user's usual one. 
+| `--threads [cores]` | Number of threads to use (default 4)
+| `--prof [cores]` | Run profiler and dump info to specifed file
 | `--version`       | Show the version of aminal and exit.
 
 # Contributors

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ func getConfig() *config.Config {
 	slomo := false
 	threads := 4
 	prof := ""
+	dpi := -1.0
 
 	if flag.Parsed() == false {
 		flag.BoolVar(&showVersion, "version", showVersion, "Output version information")
@@ -39,6 +40,7 @@ func getConfig() *config.Config {
 		flag.BoolVar(&slomo, "slomo", slomo, "Render in slow motion (useful for debugging)")
 		flag.IntVar(&threads, "threads", threads, "Number of threads to use")
 		flag.StringVar(&prof, "prof", prof, "Run profiler and dump info to specifed file")
+		flag.Float64Var(&dpi, "dpi-scale", dpi, "Override DPI scale. Defaults to 0.0 (let Aminal determine the DPI scale itself)")
 
 		flag.Parse() // actual parsing and fetching flags from the command line
 	}
@@ -61,6 +63,9 @@ func getConfig() *config.Config {
 	}
 	conf.Prof = prof
 	conf.Threads = threads
+	if dpi != -1.0 {
+		conf.DPIScale = float32(dpi)
+	}
 
 	// Override values in the configuration file with the values specified in the command line, if any.
 	if actuallyProvidedFlags["shell"] {

--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ func getConfig() *config.Config {
 	shell := ""
 	debugMode := false
 	slomo := false
+	threads := 4
+	prof := ""
 
 	if flag.Parsed() == false {
 		flag.BoolVar(&showVersion, "version", showVersion, "Output version information")
@@ -35,6 +37,8 @@ func getConfig() *config.Config {
 		flag.StringVar(&shell, "shell", shell, "Specify the shell to use")
 		flag.BoolVar(&debugMode, "debug", debugMode, "Enable debug logging")
 		flag.BoolVar(&slomo, "slomo", slomo, "Render in slow motion (useful for debugging)")
+		flag.IntVar(&threads, "threads", threads, "Number of threads to use")
+		flag.StringVar(&prof, "prof", prof, "Run profiler and dump info to specifed file")
 
 		flag.Parse() // actual parsing and fetching flags from the command line
 	}
@@ -55,6 +59,8 @@ func getConfig() *config.Config {
 	} else {
 		conf = loadConfigFile()
 	}
+	conf.Prof = prof
+	conf.Threads = threads
 
 	// Override values in the configuration file with the values specified in the command line, if any.
 	if actuallyProvidedFlags["shell"] {

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	SearchURL             string           `toml:"search_url"`
 	MaxLines              uint64           `toml:"max_lines"`
 	CopyAndPasteWithMouse bool             `toml:"copy_and_paste_with_mouse"`
+	Prof                  string           `toml:"prof"`
+	Threads               int              `toml:"threads"`
 }
 
 type KeyMappingConfig map[string]string

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/riywo/loginshell"
 	"os"
 	"runtime"
+	"runtime/pprof"
 )
 
 type callback func(terminal *terminal.Terminal, g *gui.GUI)
@@ -23,6 +24,16 @@ func main() {
 func initialize(unitTestfunc callback) {
 	conf := getConfig()
 	logger, err := getLogger(conf)
+	runtime.GOMAXPROCS(conf.Threads)
+	if conf.Prof != "" {
+		f, err := os.Create(conf.Prof)
+		defer f.Close()
+		if err != nil {
+			logger.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
 	if err != nil {
 		fmt.Printf("Failed to create logger: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
# Pull Request Template

## Description

Hello,

I have found aminal useful and hackable (since it is written in Go). However, I found the latency a bit too high when used Midnight Commander inside the terminal. So I have added a command line flag for optionally running the pprof profiler. This was not that useful as most time is spent in cgo calls, however, the option might be useful for future development.
Then I have added an option to set `runtime.GOMAXPROCS()`, and I have found than `-threads 4` makes `aminal` responsive enough to be used with `mc`. I am aware that this is just ducktape and not a solution, but it certainly makes the terminal more usable, hence please merge it if you like the idea.

Best,
Botond

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

**Test Configuration**:
* OS: Linux penguin (ChromeOS container)
* OS version: 4.19.113
* Go version:  go1.14

## Checklist:

- [X] My code follows the style guidelines of this project (gofmt)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
