### PR TITLE
Set Line.wrapped when a line wraps

### DIFF
--- a/internal/app/darktile/termutil/buffer.go
+++ b/internal/app/darktile/termutil/buffer.go
@@ -440,6 +440,7 @@ func (buffer *Buffer) write(runes ...MeasuredRune) {
 				buffer.newLineEx(true)
 
 				newLine := buffer.getCurrentLine()
+				newLine.wrapped = true
 				if len(newLine.cells) == 0 {
 					newLine.append(buffer.defaultCell(true))
 				}

--- a/internal/app/darktile/termutil/buffer_test.go
+++ b/internal/app/darktile/termutil/buffer_test.go
@@ -131,6 +131,7 @@ func TestBufferWriteIncrementsCursorCorrectly(t *testing.T) {
 	writeRaw(b, 'x')
 	require.Equal(t, uint16(1), b.CursorColumn())
 	require.Equal(t, uint16(1), b.CursorLine())
+	require.Equal(t, true, b.getCurrentLine().wrapped)
 
 	writeRaw(b, 'x')
 	require.Equal(t, uint16(2), b.CursorColumn())


### PR DESCRIPTION
In Buffer.write(), when CursorColumn() >= Width(), and AutoWrap is on, and you write a new character, set wrapped=true on the new line.