### PR TITLE
`CSI c` Device Attributes Report returns 4 to indicate sixel support

### DIFF
--- a/internal/app/darktile/termutil/csi.go
+++ b/internal/app/darktile/termutil/csi.go
@@ -306,8 +306,10 @@ func (t *Terminal) csiSendDeviceAttributesHandler(params []string) (renderRequir
 
 	// we are VT100
 	// for DA1 we'll respond ?1;2
+	// the 1 and 2 indicates that we're a VT100 with AVO
+	// the additional 4 allows modern apps to infer sixel support
 	// for DA2 we'll respond >0;0;0
-	response := "?1;2"
+	response := "?1;2;4"
 	if len(params) > 0 && len(params[0]) > 0 && params[0][0] == '>' {
 		response = ">0;0;0"
 	}


### PR DESCRIPTION
"VT100 with GPO (Graphics Processor Option)"
    
Since sixels is a "passive" feature, the 4 / GPO is usually used by modern programs to infer support for sixels.

Motivation: [ratatui-image](https://github.com/benjajaja/ratatui-image) wants to detect sixel support by either having the `4` in the `CSI c` response or some magic env var matching, and darktile uses a generic `xterm` like value for `$TERM`, so I want darktile to return `4` here.
Fixes #346 